### PR TITLE
Add CAP_DAC_OVERRIDE to init container to address race condition during Pod restart

### DIFF
--- a/manifests/eks-connector.yaml
+++ b/manifests/eks-connector.yaml
@@ -165,6 +165,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+                - DAC_OVERRIDE
               drop:
                 - all
       containers:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
EKS Connector's init container does not have `DAC_OVERRIDE` capability. This normally works fine on initial startup and on Pod reschedule, as `emptyDir` will be clear.

However init container does not handle [Pod Restarts](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#pod-restart-reasons) well, as the `emptyDir` will persist previous files which were [over hardened by SSM agent](https://github.com/aws/amazon-ssm-agent/blob/71fc9173cac81b36cc3c7a51ce16b19a7caaa86e/agent/fileutil/harden.go#L10-L47). To access/mutate those files `DAC_OVERRIDE` is necessary

*Steps to reproduce*
- Prepare an EKS cluster with two worker nodes
- Deploy EKS connector to it. Verify that two eks connector Pods are in running state.
- Restart one of the worker nodes at EC2
- Observe that one of the eks connector Pods goes into Error and eventually crashloop state.

*Tests*
Deployed eks connector with the new manifest, with above steps the issue isn't reproducible. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
