### PR TITLE
Add support for multi-platform images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/*
+!cmd/
+!pkg/
+!vendor/
+!go.*

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,51 @@
+---
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>:
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3 # https://github.com/actions/checkout
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2 # https://github.com/docker/setup-qemu-action
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2 # https://github.com/docker/setup-buildx-action
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3 # https://github.com/docker/metadata-action
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Login to container registry ${{ env.REGISTRY }} (except on PR)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 # https://github.com/docker/login-action
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+      # This may result in a '403 Forbidden' error when pushing the image unless you grant the repository write access
+      # to the package - see "Manage Actions access" at
+      # https://github.com/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }}/settings :
+      - name: Build and push container image with `docker buildx` (don't push on PR)
+        id: build-and-push
+        uses: docker/build-push-action@v2 # https://github.com/docker/build-push-action
+        with:
+          file: configuration/Dockerfile
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+on:
+  schedule:
+    - cron: '56 4 * * *'
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases:
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/coverage.out

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ imports-check-no-vendor:
 compile::
 	GOOS=windows GOARCH=amd64 $(GO_BUILD) -o $(BIN_PATH)/amd64/windows/eks-connector $(BUILD_PATH)
 	GOOS=darwin GOARCH=amd64 $(GO_BUILD) -o $(BIN_PATH)/amd64/darwin/eks-connector $(BUILD_PATH)
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -o $(BIN_PATH)/arm64/darwin/eks-connector $(BUILD_PATH)
 	GOOS=linux GOARCH=amd64 $(GO_BUILD) -o $(BIN_PATH)/amd64/linux/eks-connector $(BUILD_PATH)
 	GOOS=linux GOARCH=arm64 $(GO_BUILD) -o $(BIN_PATH)/arm64/linux/eks-connector $(BUILD_PATH)
 

--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -1,9 +1,15 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as build
+# syntax=docker/dockerfile:1
+FROM golang:1.19-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o bin/connector ./cmd
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS cert
 
 FROM scratch
-
+COPY --from=build /app/bin/connector /var/eks/connector
 # copy ca-bundle.crt from AmazonLinux2...
-COPY --from=build /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/
-COPY bin/amd64/linux/eks-connector /var/eks/connector
-
+COPY --from=cert /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/
 ENTRYPOINT ["/var/eks/connector"]


### PR DESCRIPTION
This PR adds support for multi-platform images. Specifically, it contains a GitHub action which builds and pushes images for the `linux/amd64` and `linux/arm64` platforms. The action depends on the Dockerfile, which I have updated to run the go build.

This PR also adds support for the platform `darwin/arm64` for local development.

I also plan to add a Helm chart because your script cannot be used with a tool like Argo CD. Helm is the better choice for customizing the deployment anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
