### PR TITLE
Bugfix: Fixes a bug that init container can't load from flag configuration

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,11 +13,12 @@ import (
 	"github.com/aws/amazon-eks-connector/pkg/state"
 )
 
+var initCmdViperFlag = viper.New()
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize EKS connector",
 	Run: func(cmd *cobra.Command, args []string) {
-		configProvider := config.NewProvider()
+		configProvider := config.NewProvider(initCmdViperFlag)
 		configuration, err := configProvider.Get()
 		if err != nil {
 			klog.Fatalf("failed to load configuration: %v", err)
@@ -70,7 +71,7 @@ func init() {
 	_ = initCmd.MarkFlagRequired("activation.id")
 	_ = initCmd.MarkFlagRequired("activation.code")
 
-	err := viper.BindPFlags(initCmd.Flags())
+	err := initCmdViperFlag.BindPFlags(initCmd.Flags())
 	if err != nil {
 		klog.Fatal("failed to bind cmd flags: %v", err)
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -13,12 +13,13 @@ import (
 	"github.com/aws/amazon-eks-connector/pkg/state"
 )
 
+var serverCmdViperFlag = viper.New()
 var serverCmd = &cobra.Command{
 	Use:     "server",
 	Short:   "Run EKS connector proxy server",
 	Example: "",
 	Run: func(cmd *cobra.Command, args []string) {
-		configProvider := config.NewProvider()
+		configProvider := config.NewProvider(serverCmdViperFlag)
 		configuration, err := configProvider.Get()
 		if err != nil {
 			klog.Fatalf("failed to load configuration: %v", err)
@@ -61,7 +62,7 @@ func init() {
 	serverCmd.Flags().String("state.secretNamespace",
 		"eks-connector",
 		"Kubernetes namespace of the Secret used to persist eks-connector state")
-	err := viper.BindPFlags(serverCmd.Flags())
+	err := serverCmdViperFlag.BindPFlags(serverCmd.Flags())
 	if err != nil {
 		klog.Fatal("failed to bind cmd flags: %v", err)
 	}

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -6,16 +6,17 @@ type Provider interface {
 	Get() (*Config, error)
 }
 
-func NewProvider() Provider {
-	return &viperProvider{}
+func NewProvider(v *viper.Viper) Provider {
+	return &viperProvider{viperFlag: v}
 }
 
 type viperProvider struct {
+	viperFlag *viper.Viper
 }
 
 func (p *viperProvider) Get() (*Config, error) {
 	cfg := &Config{}
-	err := viper.Unmarshal(cfg)
+	err := p.viperFlag.Unmarshal(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
currently the `init` command will ignore the flags of which the name is conflict w/ `server` command. e.g. `--state.secretNamespace`.

this is happening because we're using a shared global viper flag glob to configure both `init` and `server` command.