### PR TITLE
Chore: s/Publish/ContainerBuild/ in workflow nickname

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Container Build
 
 on:
   schedule:


### PR DESCRIPTION
Publish sounds scary, the workflow per PR doesnt write any objects to any registry