### PR TITLE
Adding /version permission to chart

### DIFF
--- a/charts/eks-connector/templates/clusterrole.yaml
+++ b/charts/eks-connector/templates/clusterrole.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eks-connector-cluster-meta-access
+rules:
+  - nonResourceURLs: [ "/version" ]
+    verbs: [ "get" ]

--- a/charts/eks-connector/templates/clusterrolebinding.yaml
+++ b/charts/eks-connector/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks:cluster-meta-view
+subjects:
+  - kind: ServiceAccount
+    namespace: eks-connector
+    name: eks-connector
+roleRef:
+  kind: ClusterRole
+  name: eks-connector-cluster-meta-access
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Follow-up of https://github.com/aws/amazon-eks-connector/pull/20, move the same changes to helm chart