### PR TITLE
Revert "Chore: Correct clusterrolebinding name in sync to static manifest"

### DIFF
--- a/charts/eks-connector/templates/clusterrolebinding.yaml
+++ b/charts/eks-connector/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: eks-connector-cluster-meta-access
+  name: eks:cluster-meta-view
 subjects:
   - kind: ServiceAccount
     namespace: eks-connector


### PR DESCRIPTION
Reverts aws/amazon-eks-connector#23