### PR TITLE
helm: allow grant userArn access upon installation

### DIFF
--- a/charts/eks-connector/templates/viewer-clusterrole.yaml
+++ b/charts/eks-connector/templates/viewer-clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks-connector-service
+subjects:
+  - kind: ServiceAccount
+    name: eks-connector
+    namespace: eks-connector
+roleRef:
+  kind: ClusterRole
+  name: eks-connector-service
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eks-connector-service
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      - users
+    verbs:
+      - impersonate
+    resourceNames:
+      {{- range $arn := .Values.authentication.allowedUserARNs }}
+      - {{ $arn }}
+      {{- end }}

--- a/charts/eks-connector/values.yaml
+++ b/charts/eks-connector/values.yaml
@@ -7,6 +7,10 @@ eks:
   # Should be a legit AWS region, such as "us-west-2"
   agentRegion:
 
+authentication:
+  # Grant some userArn access so that they can browse resources on EKS console.
+  allowedUserARNs: []
+
 replicaCount: 2
 
 images:


### PR DESCRIPTION
render corresponding RBAC objects upon helm installation


```
$ helm template  charts/eks-connector/ --set "eks.activationId=foo" --set "eks.activationCode=bar" --set "eks.agentRegion=us-west-2"  --set "authentication.allowedUserARNs={foo1,foo2}"  | less
```