### PR TITLE
Helm: Grant iam user readonly access

### DIFF
--- a/charts/eks-connector/templates/viewer-clusterrole.yaml
+++ b/charts/eks-connector/templates/viewer-clusterrole.yaml
@@ -25,3 +25,31 @@ rules:
       {{- range $arn := .Values.authentication.allowedUserARNs }}
       - {{ $arn }}
       {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks-connector-view
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  {{- range $arn := .Values.authentication.allowedUserARNs }}
+  - kind: User
+    name: {{ $arn }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks-connector-public-info-view
+roleRef:
+  kind: ClusterRole
+  name: system:public-info-viewer
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  {{- range $arn := .Values.authentication.allowedUserARNs }}
+  - kind: User
+    name: {{ $arn }}
+  {{- end }}


### PR DESCRIPTION
Dynamically grants iam users read-only access to the cluster so that users can save some manual work.