### PR TITLE
Adding a 10 sec connection timeout to the golang http client under SSM client

### DIFF
--- a/pkg/ssm/ssm.go
+++ b/pkg/ssm/ssm.go
@@ -2,6 +2,8 @@
 package ssm
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -32,6 +34,9 @@ func NewClient(agentConfig *config.AgentConfig) Client {
 	awsConfig := aws.NewConfig().
 		WithRegion(agentConfig.Region).
 		WithCredentials(credentials.AnonymousCredentials)
+	if awsConfig.HTTPClient != nil {
+		awsConfig.HTTPClient.Timeout = time.Second * 10
+	}
 
 	if agentConfig.Endpoint != "" {
 		klog.Infof("overriding SSM endpoint to %s", agentConfig.Endpoint)


### PR DESCRIPTION
This PR fixes the bug the eks-connector might hang indefinitely when the SSM API call didn't return due to network connection issue.